### PR TITLE
fix(backend+frontend): do not require tenant read permissions

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "tsc": "tsc",
     "watch": "tsc -w",
-    "dev": "concurrently \"npm run watch\" \"nodemon --delay 2000 --watch dist dist/index.js\"",
+    "dev": "concurrently \"npm run watch\" \"nodemon --delay 20 --watch dist dist/index.js\"",
     "build": "tsc",
     "start:prod": "node .",
     "start:migrate:prod": "prisma migrate deploy && npm run start:prod",

--- a/packages/backend/src/lib/auth.ts
+++ b/packages/backend/src/lib/auth.ts
@@ -44,6 +44,19 @@ const getToken = (user: User): { token: string, user: AuthUser } => {
     return { token: sign(authUser, jwtSecret), user: authUser };
 }
 
+function getPermissions(user: AuthUser | User): string[] {
+    if ('permission' in user) {
+        return user.permission.map(p => p.scope);
+    }
+
+    return user.permissions;
+}
+
+export function hasPermission(user: AuthUser | User, ...requiredPermissions: string[]) {
+    const userToCheck = user;
+    return requiredPermissions.every(p => getPermissions(userToCheck).some(up => up.endsWith(p)));
+}
+
 const auth = <Route extends string>(...scopes: string[]): core.RequestHandler<core.RouteParameters<Route>, any, any, any, AuthLocals> => {
     return (req: AuthRequest<Route>, res: AuthResponse, next: NextFunction) => {
         const auth = req.headers.authorization;

--- a/packages/client/src/views/Clients/ClientsView.vue
+++ b/packages/client/src/views/Clients/ClientsView.vue
@@ -10,7 +10,7 @@ import type { ApiTenant } from '@/types/tenant';
 const clients = await request.$get<ApiClient[]>('clients');
 const { baseApiUrl } = settingsStore();
 const { user } = userStore();
-const tenantResponse = await request.$get<ApiTenant>(`tenants/${user?.tenantId}`);
+const tenantResponse = await request.$get<Pick<ApiTenant, 'maxClients'>>(`tenants/${user?.tenantId}`);
 const tenant = tenantResponse.assertNotError();
 const fileUrl = new URL(`/system/update/file`, baseApiUrl).href;
 </script>


### PR DESCRIPTION
When the user does not have the read:tenant permission, only return the bare minimum of information

Fixes #48